### PR TITLE
OBSX-590: Pull statsd configuration from the environment, courtesy of…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,10 @@
     <version>1.0-SNAPSHOT</version>
     <artifactId>kafka_partition_availability_benchmark</artifactId>
 
+    <properties>
+        <statsd.client.version>2.0.38</statsd.client.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.prometheus</groupId>
@@ -95,6 +99,11 @@
             <artifactId>kafka-junit</artifactId>
             <version>4.1.6</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.lyft</groupId>
+            <artifactId>statsd-client</artifactId>
+            <version>${statsd.client.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/salesforce/Main.java
+++ b/src/main/java/com/salesforce/Main.java
@@ -10,6 +10,8 @@ package com.salesforce;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.lang.NonNull;
+import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdMeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +29,24 @@ public class Main {
     private static final Logger log = LoggerFactory.getLogger(Main.class);
 
     public static void initGlobalMetricsRegistry() {
-        MeterRegistry registry = new StatsdMeterRegistry(getStr -> null, Clock.SYSTEM);
+        StatsdConfig config = new StatsdConfig() {
+            @Override
+            public String get(String k) {
+                return null;
+            }
+
+            @Override
+            public int port() {
+                return com.lyft.statsd.Settings.getStatsdPort();
+            }
+
+            @Override
+            public @NonNull String host() {
+                return com.lyft.statsd.Settings.getStatsdHostname();
+            }
+        };
+
+        MeterRegistry registry = new StatsdMeterRegistry(config, Clock.SYSTEM);
         Metrics.globalRegistry.add(registry);
     }
 


### PR DESCRIPTION
Source the statsd configuration from the environment where available, which is necessary for the migration to pulse.